### PR TITLE
Use systemFunctions for MCP integration

### DIFF
--- a/electron/llm/modelFunctions.ts
+++ b/electron/llm/modelFunctions.ts
@@ -1,6 +1,6 @@
 import { ChatSessionModelFunctions, defineChatSessionFunction } from 'node-llama-cpp';
 
-export const modelFunctions = {
+export const systemFunctions = {
     getDate: defineChatSessionFunction({
         description: 'Get the current date',
         handler() {

--- a/electron/mcp/client.ts
+++ b/electron/mcp/client.ts
@@ -1,7 +1,7 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { defineChatSessionFunction } from 'node-llama-cpp';
-import { modelFunctions } from '../llm/modelFunctions.js';
+import { systemFunctions } from '../llm/modelFunctions.js';
 import { getMcpConfig } from '../settings/mcp.ts';
 
 interface Channel {
@@ -10,7 +10,7 @@ interface Channel {
 
 const channels: Channel[] = [];
 const mcpFunctions: Record<string, any> = {
-    ...modelFunctions,
+    ...systemFunctions,
 };
 
 async function registerTools(client: Client) {
@@ -60,7 +60,7 @@ async function connect() {
 
     // clear mcpFunctions but preserve modelFunctions
     Object.keys(mcpFunctions).forEach((key) => {
-        if (!(key in modelFunctions)) {
+        if (!(key in systemFunctions)) {
             delete mcpFunctions[key];
         }
     });

--- a/electron/state/llmState.ts
+++ b/electron/state/llmState.ts
@@ -19,6 +19,7 @@ import packageJson from '../../package.json';
 import { loadMcpTools } from '../mcp/client.ts';
 import { getSelectedPrompt } from '../settings/prompts.ts';
 import { eventBus } from '../utils/eventBus.ts';
+import { systemFunctions } from '../llm/modelFunctions.ts';
 
 // const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -622,7 +623,7 @@ export const llmFunctions = {
                     await chatSession.prompt(promptMessage, {
                         signal: abortSignal,
                         stopOnAbortSignal: true,
-                        functions: opts?.withTools ? mcpFunctions : undefined,
+                        functions: opts?.withTools ? mcpFunctions : systemFunctions,
                         onResponseChunk(chunk) {
                             inProgressResponse = squashMessageIntoModelChatMessages(
                                 inProgressResponse,


### PR DESCRIPTION
Refactor the code to consistently utilize `systemFunctions` instead of `modelFunctions` for MCP-related operations. This change enhances clarity and maintains a unified approach across the application.